### PR TITLE
Performance and bug fixes, new features.

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,182 +5,102 @@
     <title>browser server test</title>
   </head>
   <body>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/webtorrent/0.102.4/webtorrent.min.js"></script>
+    <!-- <script src="https://cdnjs.cloudflare.com/ajax/libs/webtorrent/0.108.6/webtorrent.min.js"></script> -->
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/webtorrent/0.114.0/webtorrent.min.js"></script>
+
+
     <script src="range-parser.js"></script>
     <script>
       const client = new WebTorrent()
       const sintel = 'magnet:?xt=urn:btih:08ada5a7a6183aae1e09d831df6748d566095a10&dn=Sintel&tr=udp%3A%2F%2Fexplodie.org%3A6969&tr=udp%3A%2F%2Ftracker.coppersurfer.tk%3A6969&tr=udp%3A%2F%2Ftracker.empire-js.us%3A1337&tr=udp%3A%2F%2Ftracker.leechers-paradise.org%3A6969&tr=udp%3A%2F%2Ftracker.opentrackr.org%3A1337&tr=wss%3A%2F%2Ftracker.btorrent.xyz&tr=wss%3A%2F%2Ftracker.fastcast.nz&tr=wss%3A%2F%2Ftracker.openwebtorrent.com&ws=https%3A%2F%2Fwebtorrent.io%2Ftorrents%2F'
+      const tears = 'https://webtorrent.io/torrents/tears-of-steel.torrent' //bunny doesnt play on all browsers, no clue why
+      const scope = '/webtorrent-server-browser/'
+      const sw = navigator.serviceWorker.register(`sw.js`, { scope })
 
       client.add(sintel, async function(torrent) {
-        const server = await torrent.createServer()
-        await server.listen()
-
-        const a = document.createElement('a')
-        a.href = a.innerText = `./webtorrent/${torrent.infoHash}/`
-        a.innerText += ' (opens in a new tab - since you need to have this page open for webtorrent to work)'
-        a.target = '_blank'
-        document.body.appendChild(a)
-
+        await sw
         const video = document.createElement('video')
         video.controls = true
-        video.src = `./webtorrent/${torrent.infoHash}/${torrent.files[5].path}`
+        video.src = `${scope}webtorrent/${torrent.infoHash}/${encodeURI(torrent.files[5].path)}`//specified scope in source and encoded uri of filepath to fix some weird filenames
+        video.style.width = '200px'
         document.body.appendChild(video)
       })
 
-      // Wish there where a easier way to get some of webtorrent's classes so i can patch stuff
-      // const WebTorrent = require('webtorrent')
-      // const { Torrent } = WebTorrent
-      const dummyTorrent = client.add('06d67cc41f44fd57241551b6d95c2d1de38121ae')
-      const torrentPrototype = Object.getPrototypeOf(dummyTorrent)
-      client.remove('06d67cc41f44fd57241551b6d95c2d1de38121ae')
+      client.add(tears, async function(torrent) {
+        await sw
+        const video = document.createElement('video')
+        video.controls = true
+        video.src = `${scope}webtorrent/${torrent.infoHash}/${encodeURI(torrent.files[8].path)}`
+        video.style.width = '200px'
+        document.body.appendChild(video)
+      })
 
-      function getPageHTML (title, pageHtml) {
-        return `<!DOCTYPE html><html lang="en"><head><meta charset="utf-8"><title>${title}</title></head><body>${pageHtml}</body></html>`
-      }
-
-      // From https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/encodeURIComponent
-      function encodeRFC5987 (str) {
-        return encodeURIComponent(str)
-          // Note that although RFC3986 reserves "!", RFC5987 does not,
-          // so we do not need to escape it
-          .replace(/['()]/g, escape) // i.e., %27 %28 %29
-          .replace(/\*/g, '%2A')
-          // The following are not required for percent-encoding per RFC5987,
-          // so we can allow for a little better readability over the wire: |`^
-          .replace(/%(?:7C|60|5E)/g, unescape)
-      }
-
-      torrentPrototype.createServer = function(requestListener) {
-        if (this.destroyed) throw new Error('torrent is destroyed')
-
-        let registration = null
-        const torrent = this
-
-        function serveIndexPage () {
-          const listHtml = torrent.files.map((file, i) => `<li><a x_download="${file.name}" href="${registration.scope}webtorrent/${torrent.infoHash}/${file.path}">${file.path}</a> (${file.length} bytes)</li>`).join('<br>')
-
-          const body = getPageHTML(
-            `${torrent.name} - WebTorrent`,
-            `<h1>${torrent.name}</h1><ol>${listHtml}</ol>`
-          )
-
-          return {
-            status: 200,
-            headers: {'Content-Type': 'text/html'},
-            body,
-          }
-        }
-
-        function serve404Page () {
-          return {
-            status: 404,
-            headers: {'Content-Type': 'text/html'},
-            body: getPageHTML('404 - Not Found', '<h1>404 - Not Found</h1>')
-          }
-        }
-
-        function serveFile (file, req) {
-          const res = {
-            status: 200,
-            headers: {
-              'Content-Type': file._getMimeType(),
-              // Support range-requests
-              'Accept-Ranges': 'bytes',
-              // Set name of file (for "Save Page As..." dialog)
-              'Content-Disposition': `inline; filename*=UTF-8''${encodeRFC5987(file.name)}`
-            }
-          }
-
-          // `rangeParser` returns an array of ranges, or an error code (number) if
-          // there was an error parsing the range.
-          let range = rangeParser(file.length, new Headers(req.headers).get('range') || '')
-
-          if (Array.isArray(range)) {
-            res.status = 206 // indicates that range-request was understood
-
-            // no support for multi-range request, just use the first range
-            range = range[0]
-
-            res.headers['Content-Range'] = `bytes ${range.start}-${range.end}/${file.length}`
-            res.headers['Content-Length'] =  `${range.end - range.start + 1}`
-          } else {
-            range = null
-            res.headers['Content-Length'] = file.length
-          }
-
-          if (req.method === 'HEAD') res.body = ''
-          else res.stream = file.createReadStream(range)
-
-          return res
-        }
-
-
-        navigator.serviceWorker.addEventListener('message', evt => {
-          const root = new URL(registration.scope).pathname
-          const url = new URL(evt.data.url)
-          const pathname = url.pathname.split(`webtorrent/${torrent.infoHash}/`)[1]
-          const respond = msg => evt.ports[0].postMessage(msg)
-
-          if (pathname === '') {
-            return respond(serveIndexPage())
-          }
-
-          const file = torrent.files.find(f => f.path === pathname)
-          const res = serveFile(file, evt.data)
-          if (res.stream) {
-            const stream = res.stream
-            delete res.stream
-
-            stream.once('end', () => {
-              respond(null)  // Signal end event
-              evt.ports[0].onmessage = null
-            })
-
-            evt.ports[0].onmessage = evt => {
-              const chunk = stream.read()
-              if (chunk === null) {
-                stream.once('readable', () => {
-                  const chunk = stream.read()
-                  respond(new Uint8Array(chunk))
-                })
-              } else {
-                respond(new Uint8Array(chunk))
-              }
-            }
-          }
-
-          respond(res)
-        })
-
+      function serveFile (file, req) {
         const res = {
-          listen(port) {
-            const scope = `./`
-            res.scope = scope
-            return navigator.serviceWorker.getRegistration(scope).then(swReg => {
-              return swReg || navigator.serviceWorker.register('sw.js', { scope })
-            }).then(swReg => {
-              registration = swReg
-              res.scope = registration.scope
-              res.registration = registration
-              let swRegTmp = swReg.installing || swReg.waiting
-
-              if (swReg.active)
-                return
-
-              return new Promise(rs => {
-                swRegTmp.onstatechange = () => {
-                  if (swRegTmp.state === 'activated') rs()
-                }
-              })
-            })
-          },
-          close() {
-            registration && registration.unregister()
+          status: 200,
+          headers: {
+            'Content-Type': file._getMimeType(),
+            // Support range-requests
+            'Accept-Ranges': 'bytes'
           }
         }
+        // force the browser to download the file if there is a specific header specified
+        if (req.headers.get('upgrade-insecure-requests') === '1') {
+          res.headers['Content-Type'] = 'application/octet-stream'
+          res.headers['Content-Disposition'] = 'attachment'
+        }
 
-        return res
+        // `rangeParser` returns an array of ranges, or an error code (number) if
+        // there was an error parsing the range.
+        let range = rangeParser(file.length, req.headers.get('range') || '')
+
+        if (Array.isArray(range)) {
+          res.status = 206 // indicates that range-request was understood
+
+          // no support for multi-range request, just use the first range
+          range = range[0]
+
+          res.headers['Content-Range'] = `bytes ${range.start}-${range.end}/${file.length}`
+          res.headers['Content-Length'] = `${range.end - range.start + 1}`
+        } else {
+          range = null
+          res.headers['Content-Length'] = file.length
+        }
+
+        res.headers['Cache-Control'] = 'no-cache, no-store, must-revalidate, max-age=0'
+        res.headers.Expires = '0'
+        res.body = req.method === 'HEAD' ? '' : 'stream'
+
+        return [res, req.method === 'GET' && file.createReadStream(range)]
       }
+
+      // kind of a fetch event from service worker but for the main thread.
+      navigator.serviceWorker.addEventListener('message', evt => {
+        let [infoHash, ...filePath] = evt.data.url.split(evt.data.scope + 'webtorrent/')[1].split('/')
+        filePath = decodeURI(filePath.join('/'))
+
+        if (!infoHash || !filePath) return
+
+        const [port] = evt.ports
+        const [response, stream] = this.serveFile(this.get(infoHash).files.find(file => file.path === filePath), new Request(evt.data.url, {
+          headers: evt.data.headers,
+          method: evt.data.method
+        }))
+        const asyncIterator = stream && stream[Symbol.asyncIterator]()
+        port.postMessage(response)
+
+        port.onmessage = async msg => {
+          if (msg.data) {
+            const chunk = (await asyncIterator.next()).value
+            port.postMessage(chunk)
+            if (!chunk) port.onmessage = null
+          } else {
+            console.log('Closing stream')
+            stream.destroy()
+            port.onmessage = null
+          }
+        }
+      })
     </script>
   </body>
 </html>

--- a/sw.js
+++ b/sw.js
@@ -1,60 +1,77 @@
-// Activate event
-// Be sure to call self.clients.claim()
-self.addEventListener('activate', evt =>  {
-	// `claim()` sets this worker as the active worker for all clients that
-	// match the workers scope and triggers an `oncontrollerchange` event for
-	// the clients.
-	return self.clients.claim()
+self.addEventListener('install', e => {
+  self.skipWaiting()
+})
+
+self.addEventListener('activate', e => {
+  return self.clients.claim()
 })
 
 self.addEventListener('fetch', evt => {
   const { request } = evt
-  const { url, method } = request
-  const headers = [...request.headers]
+  const { url, method, headers } = request
   if (!url.includes(self.registration.scope + 'webtorrent/')) return null
 
-  function getConsumer(clients) {
-    return new Promise((rs, rj) => {
+  function getConsumer (clients) {
+    return new Promise(resolve => {
       // Use race condition for whoever controls the response stream
       for (const client of clients) {
         const mc = new MessageChannel()
-        mc.port1.onmessage = evt => rs([evt.data, mc])
+        const { port1, port2 } = mc
+        port1.onmessage = evt => {
+          resolve([evt.data, mc])
+        }
         client.postMessage({
           url,
           method,
-          headers,
+          headers: [...headers],
           scope: self.registration.scope
-        }, [mc.port2])
+        }, [port2])
       }
     })
   }
 
   evt.respondWith(
     clients.matchAll({ type: 'window', includeUncontrolled: true })
-    .then(getConsumer)
-    .then(([data, consumer]) => {
-      const readable = 'body' in data ? data.body : new ReadableStream({
-        pull(controller) {
-          console.log('requesting data')
-          return new Promise(rs => {
-            consumer.port1.onmessage = evt => {
-              evt.data
-                ? controller.enqueue(evt.data) // evt.data is Uint8Array
-                : controller.close() // evt.data is null, means the stream ended
-              rs()
-            }
-            consumer.port1.postMessage(true) // send a pull request
-          })
-        },
-        cancel() {
-          // This event is never executed
-          console.log('request aborted')
-          consumer.port1.postMessage(false) // send a cancel request
-        }
-      })
+      .then(getConsumer)
+      .then(([data, mc]) => {
+        let tm = null
+        const body = data.body === 'stream'
+          ? new ReadableStream({
+              pull (controller) {
+                return new Promise(resolve => {
+                  mc.port1.onmessage = evt => {
+                    if (evt.data) {
+                      controller.enqueue(evt.data) // evt.data is Uint8Array
+                    } else {
+                      clearTimeout(tm)
+                      controller.close() // evt.data is null, means the stream ended
+                      mc.port1.onmessage = null
+                    }
+                    resolve()
+                  }
+                  // 'media player' does NOT signal a close on the stream and we cannot close it because it's locked to the reader,
+                  // so we just empty it after 5s of inactivity,
+                  // the browser will request another port anyways
+                  clearTimeout(tm)
+                  tm = setTimeout(() => {
+                    controller.close()
+                    mc.port1.postMessage(false) // send timeout
+                    mc.port1.onmessage = null
+                    resolve()
+                  }, 5000)
 
-      return new Response(readable, data)
-    })
-    .catch(console.error)
+                  mc.port1.postMessage(true) // send a pull request
+                })
+              },
+              cancel () {
+                // This event is never executed
+                mc.port1.postMessage(false) // send a cancel request
+              }
+            })
+          : data.body
+
+        return new Response(body, data)
+      })
+      .catch(console.error)
   )
 })


### PR DESCRIPTION
I used this in one of my projects, and improved on this idea a bunch.

What's changed in this PR:
- prevent RAM leaks when creating new ports, this is done by """emptying""" ports after ~5 seconds of inactivity. According to the spec, the max downtime between data requests is ~3 seconds so this gives it plenty of space.
- _tried to_ reduce video caching using headers, this caused issues when you tried to parse the file `readStream` but the browser didn't request the data because it was cached
- opening the file URL in a new tab now downloads the file, meaning there's no need of using webtorrent's `file.getBlobURL` to download files, which doubles RAM usage